### PR TITLE
Fix: Modify GenericCardSection alignment

### DIFF
--- a/spotify-home/SpotifyClone/View/Navigation/TabBar.swift
+++ b/spotify-home/SpotifyClone/View/Navigation/TabBar.swift
@@ -19,13 +19,11 @@ struct TabBar: View {
                 
                 // Home Tab
                 NavigationView {
-                    ZStack {
                         ZStack(alignment: .bottom) {
                             HomeView()
                             NowPlayingView()
                                 .onTapGesture {withAnimation {showPlayer.toggle()}}
                         }
-                    }
                     .navigationBarHidden(true)
                 }
                 .tabItem {

--- a/spotify-home/SpotifyClone/View/Sections/GenericCardSection.swift
+++ b/spotify-home/SpotifyClone/View/Sections/GenericCardSection.swift
@@ -11,7 +11,7 @@ struct GenericCardSection: View {
     var data: [GenericContent]
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 16) {
+            HStack(alignment: .firstTextBaseline, spacing: 16) {
                 ForEach(data) { item in
                     GenericCard(data: item)
                 }


### PR DESCRIPTION
### Thanks for your nice clone app. I have been a lot from your apps and Youtube. 👍
I have considered the following changes in your app. It is about HStack alignment..!

#### Before)
<img width="285" alt="스크린샷 2022-06-19 오후 4 18 28" src="https://user-images.githubusercontent.com/77485339/174470457-396e9e46-df5e-43ba-b254-17a87c4a7b4d.png">

#### After)
<img width="297" alt="스크린샷 2022-06-19 오후 4 18 41" src="https://user-images.githubusercontent.com/77485339/174470459-e93c7629-fbe9-4250-bbff-29e90a5d77c5.png">
 
And i removed one zstack in TabBar.
Thanks again for your YouTube!